### PR TITLE
remove duplicate line from unbound config

### DIFF
--- a/dnswithtor
+++ b/dnswithtor
@@ -252,7 +252,6 @@ server:
         hide-identity: yes
         hide-version: yes
         harden-glue: yes
-        harden-glue: yes
         ## because Tor only speaks TCP
         tcp-upstream: yes
 


### PR DESCRIPTION
I'm pretty sure that putting 'harden-glue: yes' twice doesn't actually make it better, so remove the second one.
