### PR TITLE
Fixed a typo walking the keylist during tag verify.

### DIFF
--- a/check-commit-signature
+++ b/check-commit-signature
@@ -235,7 +235,7 @@ for commit in "$span" ; do
                 ## test, same goes for the keyids
 
                 allowed_keyid=false
-                for keyid in "${trusted_keys[@]"; do
+                for keyid in "${trusted_keys[@]}"; do
                     if test -n "$(git tag --verify $ref | grep gpg: | grep $keyid )"; then
                         allowed_keyid=true
                     fi


### PR DESCRIPTION
Found check-commit-signature when looking for alternative 
signature-verification hooks, and saw this small typo which should
have broken the check to see if a tag's signature is from a trusted key.

Note, I haven't gotten so far as to actually run 
check-commit-signature, so this fix is untested, but it looks
obviously correct.
